### PR TITLE
SQL: map keyword to column

### DIFF
--- a/astropop/_db.py
+++ b/astropop/_db.py
@@ -68,6 +68,8 @@ def _row_dict(data, cols):
                 d = f"'{d.decode()}'"
             elif d is None:
                 d = 'NULL'
+            elif isinstance(d, bool):
+                d = str(int(d))
             comm_dict[name] = f"{d}"
         else:
             comm_dict[name] = "NULL"

--- a/astropop/_db.py
+++ b/astropop/_db.py
@@ -27,10 +27,9 @@ _ID_KEY = '__id__'
 def _sanitize_colnames(data):
     """Sanitize the colnames to avoid invalid characteres like '-'."""
     def _sanitize(key):
-        non_alpha = [ch for ch in key if not ch.isalnum()]
-        for i in non_alpha:
-            key = key.replace(i, '_')
-        return key
+        if len([ch for ch in key if not ch.isalnum() and ch != '_']) != 0:
+            raise ValueError(f'Invalid column name: {key}.')
+        return key.lower()
 
     if isinstance(data, dict):
         d = data
@@ -41,7 +40,7 @@ def _sanitize_colnames(data):
     if not isinstance(data, (list, tuple, np.ndarray)):
         raise TypeError(f'{type(data)} is not supported.')
 
-    return [_sanitize(i).lower() for i in data]
+    return [_sanitize(i) for i in data]
 
 
 def _fix_row_index(row, length):

--- a/astropop/_db.py
+++ b/astropop/_db.py
@@ -661,12 +661,13 @@ class SQLDatabase:
         """Get an item from the table."""
         self._check_table(table)
         row = _fix_row_index(row, len(self[table]))
+        column = _sanitize_colnames([column])[0]
         return self.get_column(table, column)[row]
 
     def set_item(self, table, column, row, value):
         """Set a value in a cell."""
         row = _fix_row_index(row, self.count(table))
-        column = column.lower()
+        column = _sanitize_colnames([column])[0]
         if isinstance(value, str):
             value = f"'{value}'"
         self.execute(f"UPDATE {table} SET {column}={value} "

--- a/astropop/_db.py
+++ b/astropop/_db.py
@@ -456,8 +456,13 @@ class SQLDatabase:
         """Execute a SQL command in the database."""
         logger.debug('executing sql command: "%s"',
                      str.replace(command, '\n', ' '))
-        self._cur.execute(command)
-        res = self._cur.fetchall()
+        try:
+            self._cur.execute(command)
+            res = self._cur.fetchall()
+        except sql.Error as e:
+            self._con.rollback()
+            raise e
+
         if self.autocommit:
             self.commit()
         return res

--- a/astropop/_db.py
+++ b/astropop/_db.py
@@ -589,9 +589,8 @@ class SQLDatabase:
             raise ValueError(f"{column} is a protected name.")
 
         col = _sanitize_colnames([column])[0]
-        comm = f"ALTER TABLE {table or self._table} ADD COLUMN '{col}' ;"
-        logger.debug('adding column "%s" "%s" "%s" to table "%s"',
-                     col, table or self._table)
+        comm = f"ALTER TABLE {table} ADD COLUMN '{col}' ;"
+        logger.debug('adding column "%s" to table "%s"', col, table)
         self.execute(comm)
 
         # adding the data to the table

--- a/astropop/_db.py
+++ b/astropop/_db.py
@@ -43,6 +43,19 @@ def _sanitize_colnames(data):
     return [_sanitize(i) for i in data]
 
 
+def _sanitize_value(data):
+    """Sanitize the value to avoid sql errors."""
+    if isinstance(data, str):
+        data = f"'{data}'"
+    elif isinstance(data, bytes):
+        data = f"'{data.decode()}'"
+    elif isinstance(data, bool):
+        data = str(int(data))
+    elif data is None:
+        data = 'NULL'
+    return data
+
+
 def _fix_row_index(row, length):
     """Fix the row number to be a valid index."""
     if row < 0:
@@ -60,16 +73,7 @@ def _row_dict(data, cols):
     comm_dict = {_ID_KEY: "NULL"}
     for name in cols:
         if name in data.keys():
-            d = data[name]
-            if isinstance(d, str):
-                d = f"'{d}'"
-            elif isinstance(d, bytes):
-                d = f"'{d.decode()}'"
-            elif d is None:
-                d = 'NULL'
-            elif isinstance(d, bool):
-                d = str(int(d))
-            comm_dict[name] = f"{d}"
+            comm_dict[name] = _sanitize_value(data[name])
         else:
             comm_dict[name] = "NULL"
     return comm_dict

--- a/astropop/file_collection.py
+++ b/astropop/file_collection.py
@@ -182,7 +182,7 @@ class FitsFileGroup():
 
         If unique, only unique values returned.
         """
-        vals = self._db[_headers, keyword].values()
+        vals = self._db[_headers, keyword].values
         if unique:
             vals = list(set(vals))
         return vals

--- a/astropop/file_collection.py
+++ b/astropop/file_collection.py
@@ -16,30 +16,7 @@ from .framedata import check_framedata
 from .py_utils import check_iterable
 from .logger import logger
 
-__all__ = ['list_fits_files', 'FitsFileGroup', 'create_table_summary']
-
-
-def create_table_summary(headers, n):
-    """Create a table summary of headers.
-
-    Parameters
-    ----------
-    headers: iterator
-        Iterator for a list of header files.
-    n: int
-        Number of headers to iterate.
-    """
-    summary_dict = {}
-    for i, head in enumerate(headers):
-        logger.debug('Reading file %i from %i', i, n)
-        keys = head.keys()
-        for k in keys:
-            k_lower = k.lower()
-            if k_lower not in summary_dict.keys():
-                summary_dict[k_lower] = [None]*n
-            summary_dict[k_lower][i] = head.get(k)
-
-    return Table(summary_dict)
+__all__ = ['list_fits_files', 'FitsFileGroup']
 
 
 def list_fits_files(location, fits_extensions=None,
@@ -197,7 +174,7 @@ class FitsFileGroup():
         compression = compression or self._compression
         files = self._list_files(files, location, compression)
         for i, f in enumerate(files):
-            logger.debug('reading file %i from %i', i, len(files))
+            logger.info('reading file %i from %i: %s', i, len(files), f)
             self.add_file(f)
 
     def values(self, keyword, unique=False):

--- a/astropop/file_collection.py
+++ b/astropop/file_collection.py
@@ -133,6 +133,8 @@ class FitsFileGroup():
         self._include = self._db[_metadata, 'glob_include'][0]
         self._exclude = self._db[_metadata, 'glob_exclude'][0]
         self._extensions = self._db[_metadata, 'fits_ext'].values
+        if self._extensions == [None]:
+            self._extensions = None
         self._ext = self._db[_metadata, 'ext'][0]
         self._location = self._db[_metadata, 'location'][0]
         self._compression = self._db[_metadata, 'compression'][0]

--- a/astropop/file_collection.py
+++ b/astropop/file_collection.py
@@ -243,6 +243,10 @@ class FitsFileGroup():
 
         raise KeyError(f'{item}')
 
+    def __setitem__(self, item, value):
+        """Set the value of a keyword in the summary."""
+        self._db[_headers, item] = value
+
     def _intern_yelder(self, ext=None, ret_type=None, **kwargs):
         """Iterate over files."""
         ext = ext if ext is not None else self._ext

--- a/astropop/file_collection.py
+++ b/astropop/file_collection.py
@@ -53,7 +53,7 @@ def list_fits_files(location, fits_extensions=None,
 
     f = []
     for i in fits_extensions:
-        files = glob.glob('*'+i, root_dir=location, recursive=True)
+        files = glob.glob(os.path.join(location, '**/*'+i), recursive=True)
         # filter only glob include
         if glob_include is not None:
             if not check_iterable(glob_include):
@@ -70,7 +70,7 @@ def list_fits_files(location, fits_extensions=None,
             f = [i for i in f if not fnmatch.fnmatch(i, exc)]
 
     files = sorted(f)
-    files = [os.path.join(location, i) for i in files]
+    # files = [os.path.join(location, i) for i in files]
     return files
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,37 +10,16 @@ import sqlite3
 
 
 def test_sanitize_string():
-    assert_equal(_sanitize_colnames('test'), 'test')
-    assert_equal(_sanitize_colnames('test_'), 'test_')
-    assert_equal(_sanitize_colnames('test_1'), 'test_1')
-    assert_equal(_sanitize_colnames('test-2'), 'test_2')
-    assert_equal(_sanitize_colnames('test!2'), 'test_2')
-    assert_equal(_sanitize_colnames('test@2'), 'test_2')
-    assert_equal(_sanitize_colnames('test#2'), 'test_2')
-    assert_equal(_sanitize_colnames('test$2'), 'test_2')
-    assert_equal(_sanitize_colnames('test&2'), 'test_2')
-    assert_equal(_sanitize_colnames('test*2'), 'test_2')
-    assert_equal(_sanitize_colnames('test(2)'), 'test_2_')
-    assert_equal(_sanitize_colnames('test)2'), 'test_2')
-    assert_equal(_sanitize_colnames('test[2]'), 'test_2_')
-    assert_equal(_sanitize_colnames('test]2'), 'test_2')
-    assert_equal(_sanitize_colnames('test{2}'), 'test_2_')
-    assert_equal(_sanitize_colnames('test}2'), 'test_2')
-    assert_equal(_sanitize_colnames('test|2'), 'test_2')
-    assert_equal(_sanitize_colnames('test\\2'), 'test_2')
-    assert_equal(_sanitize_colnames('test^2'), 'test_2')
-    assert_equal(_sanitize_colnames('test~2'), 'test_2')
-    assert_equal(_sanitize_colnames('test"2'), 'test_2')
-    assert_equal(_sanitize_colnames('test\'2'), 'test_2')
-    assert_equal(_sanitize_colnames('test`2'), 'test_2')
-    assert_equal(_sanitize_colnames('test<2'), 'test_2')
-    assert_equal(_sanitize_colnames('test>2'), 'test_2')
-    assert_equal(_sanitize_colnames('test=2'), 'test_2')
-    assert_equal(_sanitize_colnames('test,2'), 'test_2')
-    assert_equal(_sanitize_colnames('test;2'), 'test_2')
-    assert_equal(_sanitize_colnames('test:2'), 'test_2')
-    assert_equal(_sanitize_colnames('test?2'), 'test_2')
-    assert_equal(_sanitize_colnames('test/2'), 'test_2')
+    for i in ['test-2', 'test!2', 'test@2', 'test#2', 'test$2',
+              'test&2', 'test*2', 'test(2)', 'test)2', 'test[2]', 'test]2',
+              'test{2}', 'test}2', 'test|2', 'test\\2', 'test^2', 'test~2'
+              'test"2', 'test\'2', 'test`2', 'test<2', 'test>2', 'test=2',
+              'test,2', 'test;2', 'test:2', 'test?2', 'test/2']:
+        with pytest.raises(ValueError):
+            _sanitize_colnames(i)
+
+    for i in ['test', 'test_1', 'test_1_2', 'test_1_2', 'Test', 'Test_1']:
+        assert_equal(_sanitize_colnames(i), i.lower())
 
 
 class Test_SQLDatabase_Creation_Modify:

--- a/tests/test_filemanager.py
+++ b/tests/test_filemanager.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 
 from astropy.io import fits
-from astropy.table import Column
 from astropop.file_collection import FitsFileGroup, list_fits_files
 from astropop.testing import assert_is_instance, assert_equal, \
                              assert_in

--- a/tests/test_filemanager.py
+++ b/tests/test_filemanager.py
@@ -287,6 +287,22 @@ class Test_FitsFileGroup():
         with pytest.raises(KeyError):
             fg['NonExistingKey']
 
+    def test_fg_setitem_str(self, tmpdir):
+        tmpdir, flist = tmpdir
+        fg = FitsFileGroup(location=tmpdir/'fits', compression=False)
+        fg.add_column('new_column')
+        fg['new_column'] = ['test']*len(fg)
+        assert_equal(sorted(fg['new_column']), ['test']*len(fg))
+
+    def test_fg_setitem_tuple(self, tmpdir):
+        tmpdir, flist = tmpdir
+        fg = FitsFileGroup(location=tmpdir/'fits', compression=False)
+        fg.add_column('new_column', values=['test']*len(fg))
+        fg['new_column', -1] = 'test1'
+        expect = ['test']*len(fg)
+        expect[-1] = 'test1'
+        assert_equal(sorted(fg['new_column']), expect)
+
 
 class Test_ListFitsFiles():
     def test_list_custom_extension(self, tmpdir):


### PR DESCRIPTION
Current SQL implementation has limitations on column names and do not allow any possible keyword from fits files.

So, to store and access properly the SQL columns based on FITS keywords, we will map keywords to generic column names in an external table. The design will work as follow:

Table `key_columns` will store the mapping between keyword values and column names

| keywords         | columns |
|------------------|---------|
| 'observer'       | 'col1'  |
| 'date-obs'       | 'col2'  |
| 'space with key' | 'col3'  |
| ...              | ...     |

Table `headers` will store the header fields using the generic column names.
| col1              | col2                    | ... |
|-------------------|-------------------------|-----|
| 'Edwin Hubble'    | '1910-01-01T00:00:00.0' | ... |
| 'Galileo Galileo' | '1609-01-07T00:00:00.0' | ... |
| ...               | ...                     | ... |

When `FitsFileGroup` try to access any keyword in the table, it will first get the information of what is the generic name associated with that column, using the `_SQLColumnMap` helper. With this, any supported FITS keyword will be directly accessed without any SQL limitation.